### PR TITLE
newer job viewer...wired into the catalogstats widget [SCT-279]

### DIFF
--- a/src/plugin/config.yml
+++ b/src/plugin/config.yml
@@ -1,18 +1,17 @@
-## Demo Plugin for Screencast
 ---
 package:
-    author: Erik Pearson
+    author: Jim Thomason
     name: jobbrowser
-    description: A plugin installing a route, menu definition, and widgets implementing a simple job file browser.
-    date: January 26, 2016
+    description: A plugin to display a user's jobs
+    date: January 17, 2018
     version: 0.1.0
 source:
     modules: []
-install:    
+install:
     widgets:
         -
             module: plugins/jobbrowser/modules/browser
-            id: kb_jobbrowser_panel 
+            id: kb_jobbrowser_panel
             type: factory
 #        -
 #            module: plugins/jobbrowser/modules/browser
@@ -28,4 +27,4 @@ install:
             definition:
                 path: jobbrowser
                 label: Jobs Browser
-                icon: file
+                icon: cog


### PR DESCRIPTION
This guts the existing browser and replaces it with a drop in of the kbaseCatalogStats widget.

The way that the stats widget is loaded could probably be done better (it uses the global KBase registry since I couldn't find access to anything else), but otherwise it works.

An argument could be made whether this should have completely different code in it instead of wiring in, but I kept it very DRY.